### PR TITLE
Feature Envy in CartItem

### DIFF
--- a/src/Cart.java
+++ b/src/Cart.java
@@ -1,12 +1,8 @@
 import java.util.ArrayList;
 
 public class Cart {
-    private ArrayList<CartItem> items;
-    
-    public Cart() {
-        items = new ArrayList<>();
-    }
-    
+    private ArrayList<CartItem> items = new ArrayList<>();
+
     public void addItem(CartItem item) {
         items.add(item);
     }
@@ -14,24 +10,24 @@ public class Cart {
     public void removeItem(CartItem item) {
         items.remove(item);
     }
-    
+
     public void updateQuantity(CartItem item, int quantity) {
         for (CartItem cartItem : items) {
             if (cartItem.equals(item)) {
-                cartItem.setQuantity(quantity);
+                cartItem.updateQuantity(quantity);  // Call CartItem’s method
                 break;
             }
         }
     }
-    
+
     public void viewCartDetails() {
         System.out.println("Cart Details:");
         for (CartItem item : items) {
-            System.out.println(item.getName() + " - Quantity: " + item.getQuantity());
+            System.out.println(item.getDetails());  // Just ask CartItem
         }
-        System.out.println("\n");
+        System.out.println();
     }
-    
+
     public ArrayList<CartItem> getItems() {
         return items;
     }

--- a/src/CartItem.java
+++ b/src/CartItem.java
@@ -9,24 +9,18 @@ public class CartItem {
         this.quantity = quantity;
     }
 
-    public String getName() {
-        return itemName;
-    }
-
-    public double getPrice() {
-        return price;
-    }
-
-    public int getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(int quantity) {
+    // Cart no longer uses setQuantity directly
+    public void updateQuantity(int quantity) {
         this.quantity = quantity;
     }
 
+    // Cart doesn’t need to know how to print details
+    public String getDetails() {
+        return itemName + " - Quantity: " + quantity + " - Total: $" + getTotalPrice();
+    }
+
     public boolean equals(CartItem item) {
-        return this.itemName.equals(item.getName());
+        return this.itemName.equals(item.itemName);
     }
 
     public double getTotalPrice() {


### PR DESCRIPTION
he issue was feature envy: the Cart class was doing work that belonged to CartItem — like setting quantities and building strings to print item details.

I solved it by moving those responsibilities into CartItem. I replaced setQuantity with updateQuantity and added a getDetails() method. Now Cart just calls these methods, instead of reaching into CartItem.